### PR TITLE
Fixed an issue where the input box overflowed on some devices

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -196,8 +196,9 @@ export default function App() {
           <div className="mx-auto join">
             <button className="btn join-item">ID</button>
             <input
-              className="input input-bordered join-item "
+              className="input input-bordered join-item"
               placeholder="L_x_x_x_x_x"
+              style={{ width: "100%" }}
               onChange={handleInputChange}
             />
             <div className="btn join-item">


### PR DESCRIPTION
某些显示宽度较窄设备上输入框会溢出：

如下：

![](https://s2.loli.net/2023/06/25/owSZigXf4uDPjl6.png)

为input增加了一节style以自适应父元素宽度，修复后效果图：

![](https://s2.loli.net/2023/06/25/ikhP12ND765wfIx.png)

（使用pixel 6远程调试，桌面浏览器的移动端模拟貌似并不能复现问题）