### PR TITLE
feat(backend): use endpoint for tweetdeck to fetch tweets (WIP)

### DIFF
--- a/service/index.go
+++ b/service/index.go
@@ -272,7 +272,7 @@ func getTweeterTimeline(twitterId string, count string, maxId string) (*TweetsRe
 	url := "https://api.twitter.com/1.1/search/universal.json?count=" + count + "&modules=status&result_type=recent&pc=false&ui_lang=en-US&cards_platform=Web-13&include_entities=1&include_user_entities=1&include_cards=1&send_error_codes=1&tweet_mode=extended&include_ext_alt_text=true&include_reply_count=true"
 	queryString := "&q=from%3A" + twitterId
 	if maxId != "" {
-		queryString += " max_id%3A" + maxId
+		queryString += "%20max_id%3A" + maxId
 	}
 	url += queryString
 	req, err := http.NewRequest("GET", url, nil)
@@ -324,6 +324,10 @@ func getTweetDetails(c *gin.Context) {
 	twitterId := c.Query("twitter_id")
 	count := c.Query("count")
 
+	if twitterId == "" {
+		c.JSON(http.StatusOK, gin.H{"error": "Wrong Params"})
+		return
+	}
 	if count == "" {
 		count = "100"
 	}

--- a/service/index.go
+++ b/service/index.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	//"os"
+	"os"
 	"strconv"
 	"time"
 
@@ -51,12 +51,12 @@ type GuestTokenResponse struct {
 	Response struct {
 		GuestToken string `json:"guest_token"`
 	}
-	RateLimit       int
-	Expire int64
+	RateLimit int
+	Expire    int64
 }
 
 
-var BearerToken = "Bearer AAAAAAAAAAAAAAAAAAAAAFQODgEAAAAAVHTp76lzh3rFzcHbmHVvQxYYpTw%3DckAlMINMjmCwxUcaXbAN4XqJVdgMJaHqNOFgPMK0zN1qLqLQCF"
+var BearerToken = os.Getenv("TWITTER_BEARER_TOKEN")
 var GuestTokenHandle *GuestTokenResponse
 
 func CompletionWithoutSessionWithStreamByClaude(client *anthropic.Client, prompt string, callBack anthropic.StreamCallback) error {

--- a/service/index.go
+++ b/service/index.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
+	//"os"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -20,28 +20,42 @@ import (
 )
 
 type TweetsResponse struct {
-	Tweets []struct {
-		CreatedAt string `json:"created_at"`
-		Text      string `json:"text"`
-		ID        int64  `json:"id"`
-		Entities  struct {
-			UserMentions []struct {
-				ScreenName string `json:"screen_name"`
-			} `json:"user_mentions"`
-		} `json:"entities,omitempty"`
-		User struct {
-			Name            string `json:"name"`
-			ScreenName      string `json:"screen_name"`
-			Description     string `json:"description"`
-			FollowersCount  int    `json:"followers_count"`
-			FriendsCount    int    `json:"friends_count"`
-			CreatedAt       string `json:"created_at"`
-			FavouritesCount int    `json:"favourites_count"`
-			StatusesCount   int    `json:"statuses_count"`
-		} `json:"user"`
-	} `json:"tweets"`
-	Client string `json:"client"`
+	Modules []struct {
+		Status struct {
+			Data struct {
+				CreatedAt string `json:"created_at"`
+				Text      string `json:"full_text"`
+				ID        int64  `json:"id"`
+				Entities  struct {
+					UserMentions []struct {
+						ScreenName string `json:"screen_name"`
+					} `json:"user_mentions"`
+				} `json:"entities,omitempty"`
+				User struct {
+					Name            string `json:"name"`
+					ScreenName      string `json:"screen_name"`
+					Description     string `json:"description"`
+					FollowersCount  int    `json:"followers_count"`
+					FriendsCount    int    `json:"friends_count"`
+					CreatedAt       string `json:"created_at"`
+					FavouritesCount int    `json:"favourites_count"`
+					StatusesCount   int    `json:"statuses_count"`
+				} `json:"user"`
+			} `json:"data"`
+		} `json:"status"`
+	} `json:"modules"`
 }
+
+type GuestTokenResponse struct {
+	Response struct {
+		GuestToken string `json:"guest_token"`
+	}
+	RateLimit int
+}
+
+
+var BearerToken = "Bearer AAAAAAAAAAAAAAAAAAAAAFQODgEAAAAAVHTp76lzh3rFzcHbmHVvQxYYpTw%3DckAlMINMjmCwxUcaXbAN4XqJVdgMJaHqNOFgPMK0zN1qLqLQCF"
+var GuestTokenHandle *GuestTokenResponse
 
 func CompletionWithoutSessionWithStreamByClaude(client *anthropic.Client, prompt string, callBack anthropic.StreamCallback) error {
 	_, err := client.Complete(&anthropic.CompletionRequest{
@@ -98,34 +112,34 @@ func GetOpenAIClient() (context.Context, *openai.Client, error) {
 func getTweetPrompt(response TweetsResponse) (string, string) {
 	prompt := ""
 	maxId := ""
-	for _, tweet := range response.Tweets {
+	for _, tweet := range response.Modules {
 		var tweetPrompt string
-		tweetPrompt += "这条推文的作者是" + tweet.User.Name + "@" + tweet.User.ScreenName + "。\n"
-		tweetPrompt += "这条推文的内容是：{{" + tweet.Text + "}}\n"
-		if len(tweet.Entities.UserMentions) > 0 {
+		tweetPrompt += "这条推文的作者是" + tweet.Status.Data.User.Name + "@" + tweet.Status.Data.User.ScreenName + "。\n"
+		tweetPrompt += "这条推文的内容是：{{" + tweet.Status.Data.Text + "}}\n"
+		if len(tweet.Status.Data.Entities.UserMentions) > 0 {
 			tweetPrompt += "这条推文中提到了："
-			for _, mention := range tweet.Entities.UserMentions {
+			for _, mention := range tweet.Status.Data.Entities.UserMentions {
 				tweetPrompt += "@" + mention.ScreenName + " "
 			}
 			tweetPrompt += "\n"
 		}
-		tweetPrompt += "这条推文的发布时间是" + tweet.CreatedAt + "。\n"
+		tweetPrompt += "这条推文的发布时间是" + tweet.Status.Data.CreatedAt + "。\n"
 		prompt += tweetPrompt
-		maxId = strconv.FormatInt(tweet.ID, 10)
+		maxId = strconv.FormatInt(tweet.Status.Data.ID, 10)
 	}
 	return prompt, maxId
 }
 
 func getPromptFromTweetResponse(response TweetsResponse) string {
 	prompt := "你是一个专业的心理咨询师。你的工作是从一个人所发表的推文里专业而详细的分析其性格并分点给出依据，下面是你所需要分析的推主的一些信息：\n\n"
-	prompt += "这个推主的名字是" + response.Tweets[0].User.Name + "；" +
-		"ID 是" + response.Tweets[0].User.ScreenName + "；" +
-		"自我描述是{{" + response.Tweets[0].User.Description + "}}；" +
-		"拥有" + strconv.Itoa(response.Tweets[0].User.FollowersCount) + "个粉丝；" +
-		"关注了" + strconv.Itoa(response.Tweets[0].User.FriendsCount) + "个人；" +
-		"发表了" + strconv.Itoa(response.Tweets[0].User.StatusesCount) + "条推文；" +
-		"喜欢了" + strconv.Itoa(response.Tweets[0].User.FavouritesCount) + "条推文；" +
-		"注册于" + response.Tweets[0].User.CreatedAt + "。\n"
+	prompt += "这个推主的名字是" + response.Modules[0].Status.Data.User.Name + "；" +
+		"ID 是" + response.Modules[0].Status.Data.User.ScreenName + "；" +
+		"自我描述是{{" + response.Modules[0].Status.Data.User.Description + "}}；" +
+		"拥有" + strconv.Itoa(response.Modules[0].Status.Data.User.FollowersCount) + "个粉丝；" +
+		"关注了" + strconv.Itoa(response.Modules[0].Status.Data.User.FriendsCount) + "个人；" +
+		"发表了" + strconv.Itoa(response.Modules[0].Status.Data.User.StatusesCount) + "条推文；" +
+		"喜欢了" + strconv.Itoa(response.Modules[0].Status.Data.User.FavouritesCount) + "条推文；" +
+		"注册于" + response.Modules[0].Status.Data.User.CreatedAt + "。\n"
 
 	tweetPrompt, maxId := getTweetPrompt(response)
 	prompt += tweetPrompt
@@ -188,59 +202,108 @@ func getTweetAnalysis(c *gin.Context) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	_, _ = w.(http.Flusher)
-	var tweetResponse TweetsResponse
-	if err := c.ShouldBindJSON(&tweetResponse); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON data"})
+	twitterId := c.Query("twitter_id")
+	count := c.Query("count")
+	maxId := c.Query("max_id")
+	client := c.Query("client")
+	if twitterId == "" {
+		c.JSON(http.StatusOK, gin.H{"error": "Wrong Params"})
 		return
 	}
-	if len(tweetResponse.Tweets) == 0 {
+	if client == "" {
+		client = "claude"
+	}
+	if count == "" {
+		count = "100"
+	}
+	fmt.Fprintf(w, "\n\n抓取数据中...本次抓取量%s条\n\n", count)
+	tweetResponse, err := getTweeterTimeline(twitterId, count, maxId)
+	if err != nil || len(tweetResponse.Modules) == 0 {
 		c.JSON(http.StatusOK, gin.H{"error": "No tweets found"})
 		return
 	}
-	prompt := getPromptFromTweetResponse(tweetResponse)
+	prompt := getPromptFromTweetResponse(*tweetResponse)
 	fmt.Print(prompt)
 
 	_, _ = fmt.Fprintf(w, "\n\n请求 AI 中...一分钟还没有结果请重试 orz\n\n")
 	w.Flush()
-	if tweetResponse.Client == "claude" {
+	if client == "claude" {
 		getStreamFromClaude(c, prompt)
 	}
-	if tweetResponse.Client == "openai" {
+	if client == "openai" {
 		getStreamFromOpenAI(c, prompt)
 	}
 }
 
-// 查询用户timeline
-func getTweeterTimeline(twitterId string, count string, maxId *string) *TweetsResponse {
-	url := "https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=" + twitterId + "&count=" + count
-	if maxId != nil {
-		url += "&max_id=" + *maxId
-	}
-	req, err := http.NewRequest("GET", url, nil)
+func getGuestToken(BearerToken string) (*GuestTokenResponse, error) {
+	req, err := http.NewRequest("POST", "https://api.twitter.com/1.1/guest/activate.json", nil)
 	if err != nil {
 		fmt.Println(err)
-		return nil
+		return nil, err
 	}
-	req.Header.Add("Authorization", "Bearer "+os.Getenv("TWITTER_BEARER_TOKEN"))
-	// 这里注意要添加一个TOKEN
+	req.Header.Add("Authorization", BearerToken)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Println(err)
-		return nil
+		return nil, err
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println(err)
-		return nil
+		return nil, err
+	}
+
+	var tmpGuestTokenResponse GuestTokenResponse
+	if err = json.Unmarshal(body, &tmpGuestTokenResponse.Response); err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	tmpGuestTokenResponse.RateLimit = 300
+	return &tmpGuestTokenResponse, err
+}
+
+// 查询用户timeline
+func getTweeterTimeline(twitterId string, count string, maxId string) (*TweetsResponse, error) {
+	url := "https://api.twitter.com/1.1/search/universal.json?count=" + count + "&modules=status&result_type=recent&pc=false&ui_lang=en-US&cards_platform=Web-13&include_entities=1&include_user_entities=1&include_cards=1&send_error_codes=1&tweet_mode=extended&include_ext_alt_text=true&include_reply_count=true"
+	queryString := "&q=from%3A" + twitterId
+	if maxId != "" {
+		queryString += " max_id%3A" + maxId
+	}
+	url += queryString
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	req.Header.Add("Authorization", BearerToken)
+
+	if (GuestTokenHandle == nil || GuestTokenHandle.RateLimit <= 1) {
+		GuestTokenHandle, err = getGuestToken(BearerToken)
+	}
+	req.Header.Add("x-guest-token", GuestTokenHandle.Response.GuestToken)
+	req.Header.Add("cookie", "gt=" + GuestTokenHandle.Response.GuestToken + ";")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	GuestTokenHandle.RateLimit--
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
 	}
 	var tweetResponse TweetsResponse
-	if err = json.Unmarshal(body, &tweetResponse.Tweets); err != nil {
+	if err = json.Unmarshal(body, &tweetResponse); err != nil {
 		fmt.Println(err)
-		return nil
+		return nil, err
 	}
-	return &tweetResponse
+	return &tweetResponse, err
 }
 
 func getTweetDetails(c *gin.Context) {
@@ -254,8 +317,12 @@ func getTweetDetails(c *gin.Context) {
 	twitterId := c.Query("twitter_id")
 	count := c.Query("count")
 
-	tweetResponse := getTweeterTimeline(twitterId, count, nil)
-	if len(tweetResponse.Tweets) == 0 {
+	if count == "" {
+		count = "100"
+	}
+
+	tweetResponse, err := getTweeterTimeline(twitterId, count, "")
+	if err != nil || len(tweetResponse.Modules) == 0 {
 		c.JSON(http.StatusOK, gin.H{"error": "No tweets found"})
 		return
 	}


### PR DESCRIPTION
- Use `guest_token + bearer_token` to fetch tweet list.

## Known issues

- This endpoint sometimes return empty or very few(later than July 2023) tweets.
- The maximum number of tweets returned by this endpoint is `100`.
- ~The guest token is valid for half an hour.~

## Other

- Select model by query like #29.